### PR TITLE
bugfix - immediately redirect to mollie checkout url

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -113,8 +113,15 @@ class controller extends Package
 
     private function registerRoutes()
     {
-        Route::register('/checkout/mollieresponse', '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::validateCompletion');
-        Route::register('/checkout/ordercompletion/{oID}', '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::customerValidation', 'customervalidate', array('oID' => '\d+'));
+        Route::register(
+            '/checkout/mollieresponse',
+            '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::validateCompletion'
+        );
+        
+        Route::register(
+            '/checkout/ordercompletion/{oID}',
+            '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::customerValidation',
+        );
     }
 
     private function setupAutoloader()

--- a/controller.php
+++ b/controller.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Package\CommunityStoreMollie;
 
 /**
@@ -26,100 +27,100 @@ use Whoops\Exception\ErrorException;
 
 class controller extends Package
 {
-  protected $pkgHandle = 'community_store_mollie';
-  protected $appVersionRequired = '8.2.1';
-  protected $pkgVersion = '1.0.0';
-  protected $paymentMethodName = 'Mollie';
+    protected $pkgHandle = 'community_store_mollie';
+    protected $appVersionRequired = '8.2.1';
+    protected $pkgVersion = '1.0.0';
+    protected $paymentMethodName = 'Mollie';
 
-  public function getPackageDescription()
-  {
-    return t("Mollie Payment Method for Community Store");
-  }
-
-  public function getPackageName()
-  {
-    return t("Mollie payment method");
-  }
-
-  protected $pkgAutoloaderRegistries = [
-    'src/CommunityStore' => '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore',
-    'src/Mollie' => '\Concrete\Package\CommunityStoreMollie\Src\Mollie',
-  ];
-
-  public function on_start()
-  {
-    $this->registerRoutes();
-    $this->setupAutoloader();
-
-    Events::addListener(OrderEvent::ORDER_CREATED, function ($event) {
-      /** @var Order $order */
-      $order = $event->getOrder();
-
-      if ($order->getPaymentMethodName() !== $this->paymentMethodName) {
-        return;
-      }
-
-      Session::set('molliePaymentMethod', $_POST['molliePaymentMethod'] ?? null);
-    });
-  }
-
-  public function install()
-  {
-    $installedPackages = $this->app->make(PackageService::class)->getInstalledHandles();
-
-    if (!(is_array($installedPackages) && in_array('community_store', $installedPackages, true))) {
-      throw new ErrorException(t('This package requires that Community Store be installed'));
+    public function getPackageDescription()
+    {
+        return t("Mollie Payment Method for Community Store");
     }
 
-    parent::install();
-
-    $this->installSinglePage();
-    PaymentMethod::add('mollie', $this->paymentMethodName, $this);
-
-    $orderStatus = StoreOrderStatus::getByHandle('nodelivery');
-    if (is_object($orderStatus)){
-      Config::set('community_store.mollie.order_status_on_cancel', 'nodelivery');
-    }
-  }
-
-  public function upgrade()
-  {
-    parent::upgrade();
-    $this->installSinglePage();
-  }
-
-  public function uninstall()
-  {
-    if ($paymentMethod = PaymentMethod::getByHandle('mollie')){
-      $paymentMethod->delete();
+    public function getPackageName()
+    {
+        return t("Mollie payment method");
     }
 
-    parent::uninstall();
-  }
+    protected $pkgAutoloaderRegistries = [
+        'src/CommunityStore' => '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore',
+        'src/Mollie' => '\Concrete\Package\CommunityStoreMollie\Src\Mollie',
+    ];
 
-  private function installSinglePage()
-  {
-    $page = Page::getByPath('/dashboard/store/settings/paymollie');
+    public function on_start()
+    {
+        $this->registerRoutes();
+        $this->setupAutoloader();
 
-    if ($page->isError() || (!is_object($page))) {
-      $page = SinglePage::add('/dashboard/store/settings/paymollie', $this);
+        Events::addListener(OrderEvent::ORDER_CREATED, function ($event) {
+            /** @var Order $order */
+            $order = $event->getOrder();
 
-      $page->update([
-        'cName' => 'Mollie Payment'
-      ]);
+            if ($order->getPaymentMethodName() !== $this->paymentMethodName) {
+                return;
+            }
+
+            Session::set('molliePaymentMethod', $_POST['molliePaymentMethod'] ?? null);
+        });
     }
-  }
 
-  private function registerRoutes()
-  {
-    Route::register('/checkout/mollieresponse', '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::validateCompletion');
-    Route::register('/checkout/ordercompletion/{oID}', '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::customerValidation', 'customervalidate' ,array('oID' => '\d+'));
-  }
+    public function install()
+    {
+        $installedPackages = $this->app->make(PackageService::class)->getInstalledHandles();
 
-  private function setupAutoloader()
-  {
-    if (file_exists($this->getPackagePath() . '/vendor')) {
-      require_once $this->getPackagePath() . '/vendor/autoload.php';
+        if (!(is_array($installedPackages) && in_array('community_store', $installedPackages, true))) {
+            throw new ErrorException(t('This package requires that Community Store be installed'));
+        }
+
+        parent::install();
+
+        $this->installSinglePage();
+        PaymentMethod::add('mollie', $this->paymentMethodName, $this);
+
+        $orderStatus = StoreOrderStatus::getByHandle('nodelivery');
+        if (is_object($orderStatus)) {
+            Config::set('community_store.mollie.order_status_on_cancel', 'nodelivery');
+        }
     }
-  }
+
+    public function upgrade()
+    {
+        parent::upgrade();
+        $this->installSinglePage();
+    }
+
+    public function uninstall()
+    {
+        if ($paymentMethod = PaymentMethod::getByHandle('mollie')) {
+            $paymentMethod->delete();
+        }
+
+        parent::uninstall();
+    }
+
+    private function installSinglePage()
+    {
+        $page = Page::getByPath('/dashboard/store/settings/paymollie');
+
+        if ($page->isError() || (!is_object($page))) {
+            $page = SinglePage::add('/dashboard/store/settings/paymollie', $this);
+
+            $page->update([
+                'cName' => 'Mollie Payment'
+            ]);
+        }
+    }
+
+    private function registerRoutes()
+    {
+        Route::register('/checkout/mollieresponse', '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::validateCompletion');
+        Route::register('/checkout/ordercompletion/{oID}', '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::customerValidation', 'customervalidate', array('oID' => '\d+'));
+    }
+
+    private function setupAutoloader()
+    {
+        if (file_exists($this->getPackagePath() . '/vendor')) {
+            require_once $this->getPackagePath() . '/vendor/autoload.php';
+        }
+    }
 }

--- a/controllers/single_page/dashboard/store/settings/paymollie.php
+++ b/controllers/single_page/dashboard/store/settings/paymollie.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Package\CommunityStoreMollie\Controller\SinglePage\Dashboard\Store\Settings;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -7,17 +8,17 @@ use Concrete\Package\CommunityStoreMollie\Src\Mollie\Method;
 
 class Paymollie extends DashboardPageController
 {
-  public function view($status = null)
-  {
-    $this->set('status', $status);
-    $this->set('methods', Method::getAll());
-  }
+    public function view($status = null)
+    {
+        $this->set('status', $status);
+        $this->set('methods', Method::getAll());
+    }
 
-  public function rescan()
-  {
-    Method::rescan();
+    public function rescan()
+    {
+        Method::rescan();
 
-    $response = new RedirectResponse('/dashboard/store/settings/paymollie/rescanned');
-    $response->send();
-  }
+        $response = new RedirectResponse('/dashboard/store/settings/paymollie/rescanned');
+        $response->send();
+    }
 }

--- a/elements/mollie/checkout_form.php
+++ b/elements/mollie/checkout_form.php
@@ -4,18 +4,20 @@ extract($vars);
 ?>
 
 <?php if ($methods) { ?>
-  <?php foreach ($methods as $method) { ?>
-    <div class="form-group">
-      <div class="radio">
-        <label>
-          <input type="radio" id="molliePaymentMethod<?php echo $method->getID(); ?>" value="<?php echo $method->getMollieID(); ?>" name="molliePaymentMethod" />
-          <img src="<?php echo $method->getImage(); ?>" style="height: 24px; width: auto;" /> <?php echo $method->getTitle(); ?>
-        </label>
-      </div>
-    </div>
-  <?php } ?>
+    <?php foreach ($methods as $method) { ?>
+        <div class="form-group">
+            <div class="radio">
+                <label>
+                    <input type="radio" id="molliePaymentMethod<?php echo $method->getID(); ?>"
+                           value="<?php echo $method->getMollieID(); ?>" name="molliePaymentMethod"/>
+                    <img src="<?php echo $method->getImage(); ?>"
+                         style="height: 24px; width: auto;"/> <?php echo $method->getTitle(); ?>
+                </label>
+            </div>
+        </div>
+    <?php } ?>
 <?php } else { ?>
-  <div class="alert alert-danger">
-    <?php echo t('Error: No payment options available. Please contact the website owner.'); ?>
-  </div>
+    <div class="alert alert-danger">
+        <?php echo t('Error: No payment options available. Please contact the website owner.'); ?>
+    </div>
 <?php } ?>

--- a/elements/mollie/dashboard_form.php
+++ b/elements/mollie/dashboard_form.php
@@ -5,13 +5,13 @@ extract($vars);
 ?>
 
 <div class="form-group">
-  <label><?= t('Api Key')?></label>
-  <?php echo $form->text('mollieApiKey', $apiKey); ?>
+    <label><?= t('Api Key') ?></label>
+    <?php echo $form->text('mollieApiKey', $apiKey); ?>
 </div>
 
 <div class="form-group">
-  <label><?= t('Status of order when a payment is cancelled')?></label>
-  <?php echo $form->select('mollieOrderStatusOnCancel', $statusList, $orderStatusOnCancel); ?>
+    <label><?= t('Status of order when a payment is cancelled') ?></label>
+    <?php echo $form->select('mollieOrderStatusOnCancel', $statusList, $orderStatusOnCancel); ?>
 </div>
 
 <a href="<?php echo URL::to('/dashboard/store/settings/paymollie'); ?>" class="btn btn-default">

--- a/single_pages/dashboard/store/settings/paymollie.php
+++ b/single_pages/dashboard/store/settings/paymollie.php
@@ -7,34 +7,34 @@
 <?php } ?>
 
 <?php if (!empty($methods)) { ?>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th></th>
-        <th><?php echo t('Name'); ?></th>
-        <th><?php echo t('Minimum'); ?></th>
-        <th><?php echo t('Maximum'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php foreach ($methods as $method) { ?>
+    <table class="table table-striped">
+        <thead>
         <tr>
-          <td><img src="<?php echo $method->getImage(); ?>" /></td>
-          <td><?php echo $method->getTitle(); ?></td>
-          <td><?php echo $method->getMinimum(); ?></td>
-          <td><?php echo $method->getMaximum(); ?></td>
+            <th></th>
+            <th><?php echo t('Name'); ?></th>
+            <th><?php echo t('Minimum'); ?></th>
+            <th><?php echo t('Maximum'); ?></th>
         </tr>
-      <?php } ?>
-    </tbody>
-  </table>
+        </thead>
+        <tbody>
+        <?php foreach ($methods as $method) { ?>
+            <tr>
+                <td><img src="<?php echo $method->getImage(); ?>"/></td>
+                <td><?php echo $method->getTitle(); ?></td>
+                <td><?php echo $method->getMinimum(); ?></td>
+                <td><?php echo $method->getMaximum(); ?></td>
+            </tr>
+        <?php } ?>
+        </tbody>
+    </table>
 <?php } ?>
 
 <div class="ccm-dashboard-header-buttons">
     <form action="<?php echo $this->action('rescan'); ?>" class="form-inline" method="post">
-      <?php echo $form->submit('rescan', t('Rescan'), array('class' => 'btn btn-primary')); ?>
+        <?php echo $form->submit('rescan', t('Rescan'), array('class' => 'btn btn-primary')); ?>
 
-      <a href="<?= Url::to('/dashboard/store/settings#settings-payments')?>" class="btn btn-default">
-          <i class="fa fa-gear"></i> <?= t("General Settings")?>
-      </a>
+        <a href="<?= Url::to('/dashboard/store/settings#settings-payments') ?>" class="btn btn-default">
+            <i class="fa fa-gear"></i> <?= t("General Settings") ?>
+        </a>
     </form>
 </div>

--- a/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
@@ -1,88 +1,89 @@
 <?php
-  namespace Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie;
 
-  use Concrete\Core\Multilingual\Page\Section\Section;
-  use Concrete\Core\Routing\RedirectResponse;
-  use Concrete\Core\Support\Facade\Application;
-  use Concrete\Core\Support\Facade\Config;
-  use Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order as StoreOrder;
-  use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderStatus\OrderStatus as StoreOrderStatus;
-  use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as StorePaymentMethod;
-  use Concrete\Package\CommunityStoreMollie\Src\Mollie\Method;
-  use Concrete\Package\CommunityStoreMollie\Src\Mollie\Order\Transaction;
-  use Mollie\Api\MollieApiClient;
-  use Session;
-  use URL;
+namespace Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie;
 
-  class MolliePaymentMethod extends StorePaymentMethod
-  {
-      public function dashboardForm()
-      {
+use Concrete\Core\Multilingual\Page\Section\Section;
+use Concrete\Core\Routing\RedirectResponse;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Support\Facade\Config;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order as StoreOrder;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderStatus\OrderStatus as StoreOrderStatus;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as StorePaymentMethod;
+use Concrete\Package\CommunityStoreMollie\Src\Mollie\Method;
+use Concrete\Package\CommunityStoreMollie\Src\Mollie\Order\Transaction;
+use Mollie\Api\MollieApiClient;
+use Session;
+use URL;
+
+class MolliePaymentMethod extends StorePaymentMethod
+{
+    public function dashboardForm()
+    {
         $this->set('form', Application::getFacadeApplication()->make('helper/form'));
         $this->set('statusList', StoreOrderStatus::getList());
         $this->set('apiKey', Config::get('community_store.mollie.api_key'));
         $this->set('orderStatusOnCancel', Config::get('community_store.mollie.order_status_on_cancel'));
-      }
+    }
 
-      public function save(array $data = [])
-      {
+    public function save(array $data = [])
+    {
         $oldApiKey = Config::get('community_store.mollie.api_key');
 
         Config::save('community_store.mollie.order_status_on_cancel', $data['mollieOrderStatusOnCancel']);
         Config::save('community_store.mollie.api_key', $data['mollieApiKey']);
 
-	if ($oldApiKey !== $data['mollieApiKey']) {
-	    Method::rescan();
+        if ($oldApiKey !== $data['mollieApiKey']) {
+            Method::rescan();
         }
-      }
+    }
 
-      public function validate($args, $e)
-      {
+    public function validate($args, $e)
+    {
         $molliePaymentMethod = StorePaymentMethod::getByHandle('mollie');
 
-        if ((bool) $args['paymentMethodEnabled'][$molliePaymentMethod->getID()] === false) {
-          return $e;
+        if ((bool)$args['paymentMethodEnabled'][$molliePaymentMethod->getID()] === false) {
+            return $e;
         }
 
         if (empty($args['mollieApiKey']) || trim($args['mollieApiKey']) === '') {
-          $e->add(t('Mollie API Key must be set'));
+            $e->add(t('Mollie API Key must be set'));
         }
 
         return $e;
-      }
+    }
 
-      public function checkoutForm()
-      {
+    public function checkoutForm()
+    {
         $this->set('form', Application::getFacadeApplication()->make('helper/form'));
         $this->set('methods', Method::getAll());
-      }
+    }
 
-      public function getAction()
-      {
+    public function getAction()
+    {
         $mollie = new MollieApiClient();
-				$mollie->setApiKey(Config::get('community_store.mollie.api_key'));
+        $mollie->setApiKey(Config::get('community_store.mollie.api_key'));
 
         $order = StoreOrder::getByID(Session::get('orderID'));
         $molliePaymentMethod = Session::get('molliePaymentMethod');
 
         $payment = $mollie->payments->create([
-          'amount' => [
-            'currency' => Config::get('community_store.currency'),
-            'value' => number_format($order->getTotal(), 2, '.', ''),
-          ],
-          'description' => Config::get('concrete.site') . ' Order: ' . $order->getOrderID(),
-          'redirectUrl' => (string) URL::to('/checkout/ordercompletion/' . $order->getOrderID()),
-          'webhookUrl' => (string) URL::to('/checkout/mollieresponse'),
-          'method' => $molliePaymentMethod,
+            'amount' => [
+                'currency' => Config::get('community_store.currency'),
+                'value' => number_format($order->getTotal(), 2, '.', ''),
+            ],
+            'description' => Config::get('concrete.site') . ' Order: ' . $order->getOrderID(),
+            'redirectUrl' => (string)URL::to('/checkout/ordercompletion/' . $order->getOrderID()),
+            'webhookUrl' => (string)URL::to('/checkout/mollieresponse'),
+            'method' => $molliePaymentMethod,
         ]);
 
         Transaction::add($order, $payment->id);
 
         return $payment->getCheckoutUrl();
-      }
+    }
 
-      public static function validateCompletion()
-      {
+    public static function validateCompletion()
+    {
         $molliePaymentID = $_POST['id'];
 
         $transaction = Transaction::getByMolliePaymentID($molliePaymentID);
@@ -93,29 +94,29 @@
         $payment = $mollie->payments->get($molliePaymentID);
 
         if ($payment->isPaid()) {
-          $order->completeOrder($transaction->getMolliePaymentID());
-          $order->completePayment();
+            $order->completeOrder($transaction->getMolliePaymentID());
+            $order->completePayment();
         }
 
         if ($payment->isCanceled()) {
-          $order->updateStatus(Config::get('community_store.mollie.order_status_on_cancel'));
+            $order->updateStatus(Config::get('community_store.mollie.order_status_on_cancel'));
         }
-      }
+    }
 
-      public static function customerValidation($oID)
-      {
+    public static function customerValidation($oID)
+    {
         $section = Section::getDefaultSection();
         $languagePath = '';
 
         if (null !== $section) {
-          $languagePath = $section->getCollectionHandle();
+            $languagePath = $section->getCollectionHandle();
         }
 
         $order = StoreOrder::getByID($oID);
 
-        if(!empty($order)) {
-          $response = new RedirectResponse($languagePath . '/checkout');
-          $response->send();
+        if (!empty($order)) {
+            $response = new RedirectResponse($languagePath . '/checkout');
+            $response->send();
         }
 
         $transaction = Transaction::getByOrder($order);
@@ -127,25 +128,27 @@
         Session::set('molliePaymentMethod', '');
 
         if ($payment->isCanceled()) {
-          $order->updateStatus(Config::get('community_store.mollie.order_status_on_cancel'));
+            $order->updateStatus(Config::get('community_store.mollie.order_status_on_cancel'));
 
-          $response = new RedirectResponse($languagePath . '/cart');
-          $response->send();
+            $response = new RedirectResponse($languagePath . '/cart');
+            $response->send();
         }
 
         if ($payment->isOpen() || $payment->isPending()) {
-          $order->completeOrder($transaction->getMolliePaymentID());
+            $order->completeOrder($transaction->getMolliePaymentID());
         }
 
         $response = new RedirectResponse($languagePath . '/checkout/complete');
         $response->send();
-      }
+    }
 
-      public function isExternal() {
+    public function isExternal()
+    {
         return true;
-      }
+    }
 
-      public function markPaid() {
-          return false;
-      }
-  }
+    public function markPaid()
+    {
+        return false;
+    }
+}

--- a/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
@@ -79,7 +79,9 @@ class MolliePaymentMethod extends StorePaymentMethod
 
         Transaction::add($order, $payment->id);
 
-        return $payment->getCheckoutUrl();
+        $response = new RedirectResponse($payment->getCheckoutUrl());
+
+        return $response->send();
     }
 
     public static function validateCompletion()

--- a/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
@@ -116,9 +116,10 @@ class MolliePaymentMethod extends StorePaymentMethod
 
         $order = StoreOrder::getByID($oID);
 
-        if (!empty($order)) {
+        if (empty($order)) {
             $response = new RedirectResponse($languagePath . '/checkout');
-            $response->send();
+
+            return $response->send();
         }
 
         $transaction = Transaction::getByOrder($order);
@@ -141,7 +142,8 @@ class MolliePaymentMethod extends StorePaymentMethod
         }
 
         $response = new RedirectResponse($languagePath . '/checkout/complete');
-        $response->send();
+
+        return $response->send();
     }
 
     public function isExternal()

--- a/src/Mollie/Method.php
+++ b/src/Mollie/Method.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Package\CommunityStoreMollie\Src\Mollie;
 
 use Concrete\Core\Support\Facade\Config;
@@ -13,184 +14,184 @@ use Mollie\Api\MollieApiClient;
  */
 class Method
 {
-  /**
-   * @var int
-   *
-   * @ORM\Id
-   * @ORM\Column(type="integer")
-   * @ORM\GeneratedValue
-   */
-  protected $pID;
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    protected $pID;
 
-  /**
-   * @var string
-   *
-   * @ORM\Column(type="string")
-   */
-  protected $pMollieID;
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    protected $pMollieID;
 
-  /**
-   * @var string
-   *
-   * @ORM\Column(type="string")
-   */
-  protected $pTitle;
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    protected $pTitle;
 
-  /**
-   * @var string
-   *
-   * @ORM\Column(type="string")
-   */
-  protected $pImage;
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    protected $pImage;
 
-  /**
-   * @var float
-   *
-   * @ORM\Column(type="decimal", precision=10, scale=2, nullable=true)
-   */
-  protected $pMinimum;
+    /**
+     * @var float
+     *
+     * @ORM\Column(type="decimal", precision=10, scale=2, nullable=true)
+     */
+    protected $pMinimum;
 
-  /**
-   * @var float
-   *
-   * @ORM\Column(type="decimal", precision=10, scale=2, nullable=true)
-   */
-  protected $pMaximum;
+    /**
+     * @var float
+     *
+     * @ORM\Column(type="decimal", precision=10, scale=2, nullable=true)
+     */
+    protected $pMaximum;
 
-  /** @var string */
-  protected static $table = 'molStoreMethods';
+    /** @var string */
+    protected static $table = 'molStoreMethods';
 
-  public static function getTable(): string
-  {
-    return self::$table;
-  }
-
-  public function setMollieID(string $pMollieID): self
-  {
-    $this->pMollieID = $pMollieID;
-
-    return $this;
-  }
-
-  public function setTitle(string $pTitle): self
-  {
-    $this->pTitle = $pTitle;
-
-    return $this;
-  }
-
-  public function setImage(string $pImage): self
-  {
-    $this->pImage = $pImage;
-
-    return $this;
-  }
-
-  public function setMinimum(?float $pMinimum): self
-  {
-    $this->pMinimum = $pMinimum;
-
-    return $this;
-  }
-
-  public function setMaximum(?float $pMaximum): self
-  {
-    $this->pMaximum = $pMaximum;
-
-    return $this;
-  }
-
-  public function getID(): int
-  {
-    return $this->pID;
-  }
-
-  public function getMollieID(): string
-  {
-    return $this->pMollieID;
-  }
-
-  public function getTitle(): string
-  {
-    return $this->pTitle;
-  }
-
-  public function getImage(): string
-  {
-    return $this->pImage;
-  }
-
-  /** @return float|null */
-  public function getMinimum()
-  {
-    return $this->pMinimum;
-  }
-
-  /** @return float|null */
-  public function getMaximum(): ?float
-  {
-    return $this->pMaximum;
-  }
-
-  public function save(): void
-  {
-    $em = databaseORM::entityManager();
-    $em->persist($this);
-    $em->flush();
-  }
-
-  public function delete(): void
-  {
-    $em = databaseORM::entityManager();
-    $em->remove($this);
-    $em->flush();
-  }
-
-  public static function rescan()
-  {
-    $em = Database::connection()->getEntityManager();
-    $em->createQueryBuilder()->delete(self::class)->getQuery()->execute();
-
-    $mollie = new MollieApiClient();
-    $mollie->setApiKey(Config::get('community_store.mollie.api_key'));
-    $paymentMethods = $mollie->methods->allActive();
-
-    foreach ($paymentMethods as $paymentMethod) {
-      $method = new self();
-      $method->setMollieID($paymentMethod->id);
-      $method->setTitle($paymentMethod->description);
-      $method->setImage($paymentMethod->image->size1x);
-
-      if ($minimum = $paymentMethod->minimumAmount->value) {
-        $method->setMinimum((float) $minimum);
-      }
-
-      if ($maximum = $paymentMethod->maximumAmount->value) {
-        $method->setMaximum((float) $maximum);
-      }
-
-      $method->save();
+    public static function getTable(): string
+    {
+        return self::$table;
     }
-  }
 
-  public static function getByID($pID)
-  {
-    $em = databaseORM::entityManager();
+    public function setMollieID(string $pMollieID): self
+    {
+        $this->pMollieID = $pMollieID;
 
-    return $em->getRepository(get_class())->findOneBy(['pID' => $pID], []);
-  }
+        return $this;
+    }
 
-  public static function getByMollieID($pMollieID)
-  {
-    $em = databaseORM::entityManager();
+    public function setTitle(string $pTitle): self
+    {
+        $this->pTitle = $pTitle;
 
-    return $em->getRepository(get_class())->findOneBy(['pMollieID' => $pMollieID], []);
-  }
+        return $this;
+    }
 
-  public static function getAll()
-  {
-    $em = databaseORM::entityManager();
+    public function setImage(string $pImage): self
+    {
+        $this->pImage = $pImage;
 
-    return $em->getRepository(get_class())->findBy([], []);
-  }
+        return $this;
+    }
+
+    public function setMinimum(?float $pMinimum): self
+    {
+        $this->pMinimum = $pMinimum;
+
+        return $this;
+    }
+
+    public function setMaximum(?float $pMaximum): self
+    {
+        $this->pMaximum = $pMaximum;
+
+        return $this;
+    }
+
+    public function getID(): int
+    {
+        return $this->pID;
+    }
+
+    public function getMollieID(): string
+    {
+        return $this->pMollieID;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->pTitle;
+    }
+
+    public function getImage(): string
+    {
+        return $this->pImage;
+    }
+
+    /** @return float|null */
+    public function getMinimum()
+    {
+        return $this->pMinimum;
+    }
+
+    /** @return float|null */
+    public function getMaximum(): ?float
+    {
+        return $this->pMaximum;
+    }
+
+    public function save(): void
+    {
+        $em = databaseORM::entityManager();
+        $em->persist($this);
+        $em->flush();
+    }
+
+    public function delete(): void
+    {
+        $em = databaseORM::entityManager();
+        $em->remove($this);
+        $em->flush();
+    }
+
+    public static function rescan()
+    {
+        $em = Database::connection()->getEntityManager();
+        $em->createQueryBuilder()->delete(self::class)->getQuery()->execute();
+
+        $mollie = new MollieApiClient();
+        $mollie->setApiKey(Config::get('community_store.mollie.api_key'));
+        $paymentMethods = $mollie->methods->allActive();
+
+        foreach ($paymentMethods as $paymentMethod) {
+            $method = new self();
+            $method->setMollieID($paymentMethod->id);
+            $method->setTitle($paymentMethod->description);
+            $method->setImage($paymentMethod->image->size1x);
+
+            if ($minimum = $paymentMethod->minimumAmount->value) {
+                $method->setMinimum((float)$minimum);
+            }
+
+            if ($maximum = $paymentMethod->maximumAmount->value) {
+                $method->setMaximum((float)$maximum);
+            }
+
+            $method->save();
+        }
+    }
+
+    public static function getByID($pID)
+    {
+        $em = databaseORM::entityManager();
+
+        return $em->getRepository(get_class())->findOneBy(['pID' => $pID], []);
+    }
+
+    public static function getByMollieID($pMollieID)
+    {
+        $em = databaseORM::entityManager();
+
+        return $em->getRepository(get_class())->findOneBy(['pMollieID' => $pMollieID], []);
+    }
+
+    public static function getAll()
+    {
+        $em = databaseORM::entityManager();
+
+        return $em->getRepository(get_class())->findBy([], []);
+    }
 }

--- a/src/Mollie/Method.php
+++ b/src/Mollie/Method.php
@@ -128,19 +128,19 @@ class Method
     }
 
     /** @return float|null */
-    public function getMaximum(): ?float
+    public function getMaximum()
     {
         return $this->pMaximum;
     }
 
-    public function save(): void
+    public function save()
     {
         $em = databaseORM::entityManager();
         $em->persist($this);
         $em->flush();
     }
 
-    public function delete(): void
+    public function delete()
     {
         $em = databaseORM::entityManager();
         $em->remove($this);
@@ -174,21 +174,24 @@ class Method
         }
     }
 
-    public static function getByID($pID)
+    /** @return self|null */
+    public static function getByID(int $pID)
     {
         $em = databaseORM::entityManager();
 
         return $em->getRepository(get_class())->findOneBy(['pID' => $pID], []);
     }
 
-    public static function getByMollieID($pMollieID)
+    /** @return self|null */
+    public static function getByMollieID(string $pMollieID)
     {
         $em = databaseORM::entityManager();
 
         return $em->getRepository(get_class())->findOneBy(['pMollieID' => $pMollieID], []);
     }
 
-    public static function getAll()
+    /** @return self[] */
+    public static function getAll(): array
     {
         $em = databaseORM::entityManager();
 

--- a/src/Mollie/Order/Transaction.php
+++ b/src/Mollie/Order/Transaction.php
@@ -80,14 +80,14 @@ class Transaction
         return $this->pID;
     }
 
-    public function save(): void
+    public function save()
     {
         $em = databaseORM::entityManager();
         $em->persist($this);
         $em->flush();
     }
 
-    public function delete(): void
+    public function delete()
     {
         $em = databaseORM::entityManager();
         $em->remove($this);
@@ -116,27 +116,31 @@ class Transaction
         return $this;
     }
 
-    public static function getByID(int $tID): self
+    /** @return self|null */
+    public static function getByID(int $tID)
     {
         $em = databaseORM::entityManager();
 
         return $em->getRepository(get_class())->findOneBy(['tID' => $tID], []);
     }
 
-    public static function getByOrder(Order $order): self
+    /** @return self|null */
+    public static function getByOrder(Order $order)
     {
         $em = databaseORM::entityManager();
 
         return $em->getRepository(get_class())->findOneBy(['order' => $order], []);
     }
 
-    public static function getByMolliePaymentID(string $molliePaymentID): self
+    /** @return self|null */
+    public static function getByMolliePaymentID(string $molliePaymentID)
     {
         $em = databaseORM::entityManager();
 
         return $em->getRepository(get_class())->findOneBy(['pID' => $molliePaymentID], []);
     }
 
+    /** @return self[] */
     public static function getAll(): array
     {
         $em = databaseORM::entityManager();

--- a/src/Mollie/Order/Transaction.php
+++ b/src/Mollie/Order/Transaction.php
@@ -130,7 +130,7 @@ class Transaction
         return $em->getRepository(get_class())->findOneBy(['order' => $order], []);
     }
 
-    public static function getByMolliePaymentID(int $molliePaymentID): self
+    public static function getByMolliePaymentID(string $molliePaymentID): self
     {
         $em = databaseORM::entityManager();
 

--- a/src/Mollie/Order/Transaction.php
+++ b/src/Mollie/Order/Transaction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Package\CommunityStoreMollie\Src\Mollie\Order;
 
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order;
@@ -11,135 +12,135 @@ use Concrete\Core\Support\Facade\DatabaseORM;
  */
 class Transaction
 {
-  /**
-   * @var int
-   *
-   * @ORM\Id
-   * @ORM\Column(type="integer")
-   * @ORM\GeneratedValue
-   */
-  protected $tID;
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    protected $tID;
 
-  /**
-   * @var int
-   *
-   * @ORM\Column(type="integer")
-   */
-  protected $oID;
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     */
+    protected $oID;
 
-  /**
-   * @var int
-   *
-   * @ORM\Column(type="string")
-   */
-  protected $pID;
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="string")
+     */
+    protected $pID;
 
-  /**
-   * @var Order
-   *
-   * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order", cascade={"persist"})
-   * @ORM\JoinColumn(name="oID", referencedColumnName="oID", onDelete="CASCADE")
-   */
-  protected $order;
+    /**
+     * @var Order
+     *
+     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order", cascade={"persist"})
+     * @ORM\JoinColumn(name="oID", referencedColumnName="oID", onDelete="CASCADE")
+     */
+    protected $order;
 
-  /** @var string */
-  protected static $table = 'molStoreOrderTransactions';
+    /** @var string */
+    protected static $table = 'molStoreOrderTransactions';
 
-  public static function getTable(): string
-  {
-    return self::$table;
-  }
+    public static function getTable(): string
+    {
+        return self::$table;
+    }
 
-  public function setOrder(Order $order): self
-  {
-    $this->order = $order;
+    public function setOrder(Order $order): self
+    {
+        $this->order = $order;
 
-    return $this;
-  }
+        return $this;
+    }
 
-  public function setMolliePaymentID(string $molliePaymentID): self
-  {
-    $this->pID = $molliePaymentID;
+    public function setMolliePaymentID(string $molliePaymentID): self
+    {
+        $this->pID = $molliePaymentID;
 
-    return $this;
-  }
+        return $this;
+    }
 
-  public function getID(): int
-  {
-    return $this->tID;
-  }
+    public function getID(): int
+    {
+        return $this->tID;
+    }
 
-  public function getOrder(): Order
-  {
-    return $this->order;
-  }
+    public function getOrder(): Order
+    {
+        return $this->order;
+    }
 
-  public function getMolliePaymentID(): string
-  {
-    return $this->pID;
-  }
+    public function getMolliePaymentID(): string
+    {
+        return $this->pID;
+    }
 
-  public function save(): void
-  {
-    $em = databaseORM::entityManager();
-    $em->persist($this);
-    $em->flush();
-  }
+    public function save(): void
+    {
+        $em = databaseORM::entityManager();
+        $em->persist($this);
+        $em->flush();
+    }
 
-  public function delete(): void
-  {
-    $em = databaseORM::entityManager();
-    $em->remove($this);
-    $em->flush();
-  }
+    public function delete(): void
+    {
+        $em = databaseORM::entityManager();
+        $em->remove($this);
+        $em->flush();
+    }
 
-  public static function add(Order $order, string $molliePaymentID): self
-  {
-    $entity = new self();
+    public static function add(Order $order, string $molliePaymentID): self
+    {
+        $entity = new self();
 
-    $entity
-      ->setOrder($order)
-      ->setMolliePaymentID($molliePaymentID)
-      ->save();
+        $entity
+            ->setOrder($order)
+            ->setMolliePaymentID($molliePaymentID)
+            ->save();
 
-    return $entity;
-  }
+        return $entity;
+    }
 
-  public function update(Order $order, string $molliePaymentID): self
-  {
-    $this
-      ->setOrder($order)
-      ->setMolliePaymentID($molliePaymentID)
-      ->save();
+    public function update(Order $order, string $molliePaymentID): self
+    {
+        $this
+            ->setOrder($order)
+            ->setMolliePaymentID($molliePaymentID)
+            ->save();
 
-    return $this;
-  }
+        return $this;
+    }
 
-  public static function getByID(int $tID): self
-  {
-    $em = databaseORM::entityManager();
+    public static function getByID(int $tID): self
+    {
+        $em = databaseORM::entityManager();
 
-    return $em->getRepository(get_class())->findOneBy(['tID' => $tID], []);
-  }
+        return $em->getRepository(get_class())->findOneBy(['tID' => $tID], []);
+    }
 
-  public static function getByOrder(Order $order): self
-  {
-    $em = databaseORM::entityManager();
+    public static function getByOrder(Order $order): self
+    {
+        $em = databaseORM::entityManager();
 
-    return $em->getRepository(get_class())->findOneBy(['order' => $order], []);
-  }
+        return $em->getRepository(get_class())->findOneBy(['order' => $order], []);
+    }
 
-  public static function getByMolliePaymentID(int $molliePaymentID): self
-  {
-    $em = databaseORM::entityManager();
+    public static function getByMolliePaymentID(int $molliePaymentID): self
+    {
+        $em = databaseORM::entityManager();
 
-    return $em->getRepository(get_class())->findOneBy(['pID' => $molliePaymentID], []);
-  }
+        return $em->getRepository(get_class())->findOneBy(['pID' => $molliePaymentID], []);
+    }
 
-  public static function getAll(): array
-  {
-    $em = databaseORM::entityManager();
+    public static function getAll(): array
+    {
+        $em = databaseORM::entityManager();
 
-    return $em->getRepository(get_class())->findBy([], []);
-  }
+        return $em->getRepository(get_class())->findBy([], []);
+    }
 }


### PR DESCRIPTION
@Mesign, @Jozzeh, @Mesuva 

Here is the fix for the error that @Mesign was getting on checkout: "The form has expired".
The solution seemed to be that we immediately should have redirected to the mollie checkout, rather than go through the redirect form automatically provided by Community Store.

The first commit was just for my own sake, because the difference in tabs (2 vs 4 spaces) was bugging me.

The other issues that slipped through the update I did a few months ago seemed to have been a wrong parameter type in the method getByMolliePaymentID, and a wrong check if order exists on redirecting to the complete page.

I hope this solves al your issues. I tested it on Concrete5 8.5.4 with PHP 7.4. 
I did also remove all nullable return type to make it compatible with PHP 7.0

Maybe test this in a local environment first, I would like a second pair of eyes to resolve all open issues.

Thanks!