### PR TITLE
bugfix - trailing slash on order completion redirect

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -117,7 +117,7 @@ class controller extends Package
             '/checkout/mollieresponse',
             '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::validateCompletion'
         );
-        
+
         Route::register(
             '/checkout/ordercompletion/{oID}',
             '\Concrete\Package\CommunityStoreMollie\Src\CommunityStore\Payment\Methods\Mollie\MolliePaymentMethod::customerValidation',

--- a/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Mollie/MolliePaymentMethod.php
@@ -117,7 +117,7 @@ class MolliePaymentMethod extends StorePaymentMethod
         $order = StoreOrder::getByID($oID);
 
         if (empty($order)) {
-            $response = new RedirectResponse($languagePath . '/checkout');
+            $response = new RedirectResponse('/' . $languagePath . '/checkout');
 
             return $response->send();
         }
@@ -141,7 +141,7 @@ class MolliePaymentMethod extends StorePaymentMethod
             $order->completeOrder($transaction->getMolliePaymentID());
         }
 
-        $response = new RedirectResponse($languagePath . '/checkout/complete');
+        $response = new RedirectResponse('/' . $languagePath . '/checkout/complete');
 
         return $response->send();
     }


### PR DESCRIPTION
After completing an order, it redirected to `/checkout/ordercompletion/checkout/complete`
This was because the redirect response did not have a trailing slash.
Now, it will redirect to `/checkout/complete`